### PR TITLE
ユーザー新規登録画面の実装修正

### DIFF
--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -1,6 +1,8 @@
 @import "application.scss";
 /* 新規登録画面のCSS*/
 
+
+
 .registrations{
   height: 100vh;
   width: 100vw;
@@ -11,10 +13,10 @@
     background-color: #EEEEEE;
 
     .infomation-content{
-      height: 2500px;
       width: 700px;
       background-color: white;
       margin: auto;
+      padding-bottom: 50px;
 
       .center-top{
         height: 100px;
@@ -84,6 +86,14 @@
               padding-left: 10px;
               font-size: 15px;
             }
+
+            .text-errors{
+              color: red;
+              font-size: 15px;
+              padding-top: 15px;
+              padding-left: 15px;
+              font-weight: normal;
+            }
           }
         }
 
@@ -129,6 +139,13 @@
               padding-left: 10px;
               font-size: 15px;
             }
+
+            .email-errors{
+              color: red;
+              font-size: 15px;
+              padding-top: 15px;
+              padding-left: 15px;
+            }
           }
         }  
 
@@ -173,6 +190,13 @@
               margin: auto;
               padding-left: 10px;
               font-size: 15px;
+            }
+
+            .password-errors{
+              color: red;
+              font-size: 15px;
+              padding-top: 15px;
+              padding-left: 15px;
             }
           }
         }
@@ -236,6 +260,7 @@
           .name-top-bottom{
             margin-top: 5px;
             display: flex;
+            position: relative;
 
             .name-form-left{
               height: 50px;
@@ -256,6 +281,21 @@
               font-size: 15px;
             }
           }
+          
+          .family_name_kanji-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+
+          .first_name_kanji-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+          
         }
 
         .information-kana{
@@ -311,6 +351,21 @@
               font-size: 15px;
             }
           }
+        
+          .family_name_kana-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+
+          .first_name_kana-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+          
         }
 
         .information-birthday{
@@ -386,6 +441,48 @@
             .birthday-top-bottom-day-text{
               margin-top: 18px;
             }
+
+            .year-errors{
+              color: red;
+              font-size: 15px;
+              padding-top: 15px;
+              padding-left: 15px;
+            }
+
+            .month-errors{
+              color: red;
+              font-size: 15px;
+              padding-top: 15px;
+              padding-left: 15px;
+            }
+
+            .day-errors{
+              color: red;
+              font-size: 15px;
+              padding-top: 15px;
+              padding-left: 15px;
+            }
+          }
+
+          .year-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+
+          .month-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+
+          .day-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
           }
         }
 
@@ -454,6 +551,20 @@
               font-size: 15px;
             }
           }
+
+          .family_name_kanji-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+
+          .first_name_kanji-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
         }
 
         .information-send-kana{
@@ -509,6 +620,20 @@
               font-size: 15px;
             }
           }
+
+          .family_name_kana-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+
+          .first_name_kana-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
         }
 
         .information-zip-code{
@@ -554,6 +679,14 @@
               font-size: 15px;
             }
           }
+
+          .postal_code-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+          
         }
 
         .information-state{
@@ -590,12 +723,20 @@
             margin-top: 5px;
 
             select{
-            height: 50px;
-            width: 350px;
-            background-color: white;
-            font-size: 15px;
-           }
+              height: 50px;
+              width: 350px;
+              background-color: white;
+              font-size: 15px;
+            }
           }
+
+          .prefecture-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
+
         }
 
         .information-municipalities{
@@ -641,6 +782,13 @@
               font-size: 15px;
             }
           }
+
+          .municipalities-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
+          }
         }
 
         .information-street-number{
@@ -685,6 +833,13 @@
               padding-left: 10px;
               font-size: 15px;
             }
+          }
+
+          .block_number-errors{
+            color: red;
+            font-size: 15px;
+            padding-top: 15px;
+            padding-left: 15px;
           }
         }
 

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -1,7 +1,12 @@
 @import "application.scss";
 /* 新規登録画面のCSS*/
 
-
+@mixin errors{
+  color: red;
+  font-size: 15px;
+  padding: 15px 0 0 15px;
+  font-weight: normal;
+}
 
 .registrations{
   height: 100vh;
@@ -88,11 +93,7 @@
             }
 
             .text-errors{
-              color: red;
-              font-size: 15px;
-              padding-top: 15px;
-              padding-left: 15px;
-              font-weight: normal;
+              @include errors;
             }
           }
         }
@@ -141,10 +142,7 @@
             }
 
             .email-errors{
-              color: red;
-              font-size: 15px;
-              padding-top: 15px;
-              padding-left: 15px;
+              @include errors;
             }
           }
         }  
@@ -193,10 +191,7 @@
             }
 
             .password-errors{
-              color: red;
-              font-size: 15px;
-              padding-top: 15px;
-              padding-left: 15px;
+              @include errors;
             }
           }
         }
@@ -283,17 +278,11 @@
           }
           
           .family_name_kanji-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
 
           .first_name_kanji-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
           
         }
@@ -353,17 +342,11 @@
           }
         
           .family_name_kana-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
 
           .first_name_kana-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
           
         }
@@ -441,48 +424,17 @@
             .birthday-top-bottom-day-text{
               margin-top: 18px;
             }
-
-            .year-errors{
-              color: red;
-              font-size: 15px;
-              padding-top: 15px;
-              padding-left: 15px;
-            }
-
-            .month-errors{
-              color: red;
-              font-size: 15px;
-              padding-top: 15px;
-              padding-left: 15px;
-            }
-
-            .day-errors{
-              color: red;
-              font-size: 15px;
-              padding-top: 15px;
-              padding-left: 15px;
-            }
           }
-
           .year-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
 
           .month-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
 
           .day-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
         }
 
@@ -553,17 +505,11 @@
           }
 
           .family_name_kanji-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
 
           .first_name_kanji-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
         }
 
@@ -622,17 +568,11 @@
           }
 
           .family_name_kana-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
 
           .first_name_kana-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
         }
 
@@ -681,10 +621,7 @@
           }
 
           .postal_code-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
           
         }
@@ -731,10 +668,7 @@
           }
 
           .prefecture-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
 
         }
@@ -784,10 +718,7 @@
           }
 
           .municipalities-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
         }
 
@@ -836,10 +767,7 @@
           }
 
           .block_number-errors{
-            color: red;
-            font-size: 15px;
-            padding-top: 15px;
-            padding-left: 15px;
+            @include errors;
           }
         }
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -21,5 +21,4 @@ class Address < ApplicationRecord
   validates :postal_code,         presence: true
   validates :municipalities,      presence: true
   validates :block_number,        presence: true
-  validates :phone_number,      uniqueness: true
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,12 +1,7 @@
 .registrations
   .registrations-header
     = render partial: '/layouts/header_sub'
-    = devise_error_messages!
-    - if @address
-      = @address.each do |error|
-        error
     
-
   .registrations-information
     .infomation-content
       .center-top
@@ -26,6 +21,11 @@
                     必須
               .nickname-top-bottom
                 = form.text_field :nickname, placeholder:  "例）フリマ太郎", class:"text-form"
+                - if resource.errors.any?
+                  - resource.errors.full_messages_for(:nickname).each do |message|
+                    .text-errors
+                      = message
+                
           .information-mail
             .mail-top
               .mail-top-address
@@ -35,6 +35,10 @@
                   必須
             .mail-top-bottom
               = form.text_field :email, placeholder: "PC ・ 携帯どちらでも可", class:"mail-form"
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:email).each do |message|
+                  .email-errors
+                    = message
           .information-password
             .password-top
               .password-top-address
@@ -44,6 +48,10 @@
                   必須
             .password-top-bottom
               = form.password_field :password, placeholder: "7文字以上の半角英数字",  class:"password-form"
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:password).each do |message|
+                  .password-errors
+                    = message
             .information-password
               .password-top
                 .password-top-address
@@ -53,6 +61,10 @@
                     必須
               .password-top-bottom
                 = form.password_field :password_confirmation, label: :password_confirmation, placeholder: "7文字以上の半角英数字", class:"password-form"
+                - if resource.errors.any?
+                  - resource.errors.full_messages_for(:password_confirmation).each do |message|
+                    .password-errors
+                      = message
           .information-attention
             ※ 英字と数字の両方を含めて設定してください
           .information-idintity-verification
@@ -69,6 +81,14 @@
             .name-top-bottom
               = form.text_field :family_name_kanji, placeholder: "例）中村", class:"name-form-left"
               = form.text_field :first_name_kanji, placeholder: "例）悠真", class:"name-form-right"
+            - if resource.errors.any?
+              - resource.errors.full_messages_for(:family_name_kanji).each do |message|
+                .family_name_kanji-errors
+                  = message
+            - if resource.errors.any?
+              - resource.errors.full_messages_for(:first_name_kanji).each do |message|
+                .first_name_kanji-errors
+                  = message
           .information-kana
             .kana-top
               .kana-top-address
@@ -79,6 +99,14 @@
             .kana-top-bottom
               = form.text_field :family_name_kana, placeholder: "例）ナカムラ", class:"kana-form-left"
               = form.text_field :first_name_kana, placeholder: "例）ユウマ", class:"kana-form-right"
+            - if resource.errors.any?
+              - resource.errors.full_messages_for(:family_name_kana).each do |message|
+                .family_name_kana-errors
+                  = message
+            - if resource.errors.any?
+              - resource.errors.full_messages_for(:first_name_kana).each do |message|
+                .first_name_kana-errors
+                  = message
           .information-birthday
             .birthday-top
               .birthday-top-name
@@ -99,6 +127,18 @@
                 = form.collection_select :day_id, Day.all, :id, :day,  class: "day-box"
               .birthday-top-bottom-day-text
                 日
+            - if resource.errors.any?
+              - resource.errors.full_messages_for(:year_id).each do |message|
+                .year-errors
+                  = message
+            - if resource.errors.any?
+              - resource.errors.full_messages_for(:month_id).each do |message|
+                .month-errors
+                  = message
+            - if resource.errors.any?
+              - resource.errors.full_messages_for(:day_id).each do |message|
+                .day-errors
+                  = message
           .information-birthday-attention
             ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
           .information-address
@@ -114,6 +154,14 @@
               .send-name-top-bottom
                 = f.text_field :family_name_kanji, placeholder:  "例）中村",  class:"send-name-form-left"
                 = f.text_field :first_name_kanji, placeholder: "例）悠真",  class:"send-name-form-right"
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:"address.family_name_kanji").each do |message|
+                  .family_name_kanji-errors
+                    = message
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:"address.first_name_kanji").each do |message|
+                  .first_name_kanji-errors
+                    = message
             .information-send-kana
               .send-kana-top
                 .send-kana-top-hull
@@ -124,6 +172,14 @@
               .send-kana-top-bottom
                 = f.text_field :family_name_kana, placeholder: "例）ナカムラ", class:"send-kana-form-left"
                 = f.text_field :first_name_kana, placeholder: "例）ユウマ",  class:"send-kana-form-right"
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:"address.family_name_kana").each do |message|
+                  .family_name_kana-errors
+                    = message
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:"address.first_name_kana").each do |message|
+                  .first_name_kana-errors
+                    = message
             .information-zip-code
               .zip-code-top
                 .zip-code-top-address
@@ -133,6 +189,10 @@
                     必須
               .zip-code-top-bottom
                 = f.text_field :postal_code, placeholder: "例）123-4567", class:"zip-code-form"
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:"address.postal_code").each do |message|
+                  .postal_code-errors
+                    = message
             .information-state
               .state-top
                 .state-top-address
@@ -142,6 +202,10 @@
                     必須
               .state-top-bottom
                 = f.collection_select :prefecture_id, Prefecture.all, :id, :name,  class: "state-box"
+                - if resource.errors.any?
+                  - resource.errors.full_messages_for(:"address.prefecture_id").each do |message|
+                    .prefecture-errors
+                      = message
             .information-municipalities
               .municipalities-top
                 .municipalities-top-address
@@ -151,6 +215,10 @@
                     必須
               .municipalities-top-bottom
                 = f.text_field :municipalities, placeholder: "例）渋谷区西原", class:"municipalities-form"
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:"address.municipalities").each do |message|
+                  .municipalities-errors
+                    = message
             .information-street-number
               .street-number-top
                 .street-number-top-address
@@ -160,6 +228,10 @@
                     必須
               .street-number-top-bottom
                 = f.text_field :block_number, placeholder: "例）西原1-19-10", class:"street-number-form"
+              - if resource.errors.any?
+                - resource.errors.full_messages_for(:"address.block_number").each do |message|
+                  .block_number-errors
+                    = message
             .information-building
               .building-top
                 .building-top-address

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module FreemarketSample70a
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,142 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,207 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が不一致
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/model .ja.yml
+++ b/config/locales/model .ja.yml
@@ -1,0 +1,25 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: 確認用パスワード
+        remember_me: 次回から自動的にログイン
+        nickname: ニックネーム
+        family_name_kanji: 名字
+        first_name_kanji : 名前
+        family_name_kana : 名字カナ
+        first_name_kana  : 名前カナ
+        year_id   : 西暦
+        month_id : 誕生月
+        day_id : 誕生日
+      address:
+        family_name_kanji: 名字
+        first_name_kanji : 名前
+        family_name_kana : 名字カナ
+        first_name_kana  : 名前カナ
+        postal_code : 郵便番号
+        municipalities: 市町村区
+        block_number: 番地
+        prefecture_id: 都道府県


### PR DESCRIPTION
＃what
ユーザー新規登録画面のバリデーション表示を各項目の下に表示できるようにした（日本語表示）。電話番号の入力が空でも登録できるようバリデーションの削除も行った。

#why
バリデーションの表示を各項目の下に表示することでどこにエラーが出ているのか明確になる。電話番号は任意での登録にしたいため。