### PR TITLE
商品削除機能修正

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,7 +4,7 @@ class Product < ApplicationRecord
   belongs_to_active_hash :shipping_payer
   belongs_to_active_hash :condition
   belongs_to_active_hash :shipping_from_area
-  has_many   :images, dependent: :destroy
+  has_many   :images, dependent: :delete_all
 
   belongs_to :user
   belongs_to :category


### PR DESCRIPTION
# what
商品削除ボタン押下時にエラーとなる事象を解消
商品削除時に、商品に紐づく画像情報が削除されないため、商品が削除できずにエラーとなっていた

# why
商品を削除できるようにするため