### PR TITLE
子カテゴリの不具合修正

### DIFF
--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -65,7 +65,7 @@
                   -# 子カテゴリボックス
               #children_wrapper.listing-select-wrapper__added
                 .listing-select-wrapper__box
-                  = f.collection_select :category_id, @product_children_category, :id, :name, {prompt: ""}, {id: "grandchild_category"}
+                  = f.collection_select :category_id, @product_children_category, :id, :name, {prompt: ""}, {id: "existing_child_category"}
                   -# 孫カテゴリボックス
               #grandchildren_wrapper.listing-select-wrapper__added
                 .listing-select-wrapper__box


### PR DESCRIPTION
# What 
edit画面のカテゴリ選択ボックスにおいて子カテゴリを真っ先に修正すると孫カテゴリが変更されない不具合を修正しました。
# Why
商品の孫カテゴリを変更したい場合に親カテゴリから変更しなければならず不便だから。
